### PR TITLE
Deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.12)
 
 # project variables
 project(spdlog_setup VERSION 0.3.3 LANGUAGES CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.6)
 
 # project variables
 project(spdlog_setup VERSION 0.3.3 LANGUAGES CXX)


### PR DESCRIPTION
The newest cmake 3.27 is warning, that everything below cmake 3.5 will not be supported in the future. Therefore, increasing the minimum requirements should make this a bit more future proofed. 